### PR TITLE
Escape strings when generating an rss item

### DIFF
--- a/rss/rss.go
+++ b/rss/rss.go
@@ -76,10 +76,10 @@ func GetItems(items []FeedItem) []string {
 }
 
 const RSS_ITEM = `<item>
-  <title>%s</title>
-  <link>%s</link>
-  <description>%s</description>
-  <pubDate>%s</pubDate>
+  <title><![CDATA[%s]]></title>
+  <link><![CDATA[%s]]></link>
+  <description><![CDATA[%s]]></description>
+  <pubDate><![CDATA[%s]]></pubDate>
 </item>`
 
 func OutputRSSItem(pubdate, title, brief, link string) string {


### PR DESCRIPTION
This change ensures RSS items are properly escaped. Otherwise an item with special character such as `&` or `>` will generate an invalid RSS document.

I have left the other function, `OutputRSS`, as it is since its input seem more unlikely to be controlled by an external user but you might want to fix it also (the `items` argument would be already escaped but the rest not).